### PR TITLE
Normalize emails to lowercase

### DIFF
--- a/app/forms/edit_account.py
+++ b/app/forms/edit_account.py
@@ -1,6 +1,7 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, SubmitField
 from wtforms.validators import DataRequired, Optional
+from app.util.fields import FSUIDField
 
 class EditAccount(FlaskForm):
     """EditAccount
@@ -18,7 +19,7 @@ class EditAccount(FlaskForm):
         DataRequired()
     ])
 
-    fsuid = StringField('FSUID', validators=[
+    fsuid = FSUIDField('FSUID', validators=[
         Optional(strip_whitespace=True)
     ])
 

--- a/app/forms/login.py
+++ b/app/forms/login.py
@@ -1,8 +1,9 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, PasswordField, SubmitField
+from wtforms import PasswordField, SubmitField
 from wtforms.validators import DataRequired, Email
 
 from app.util.auth2 import get_account
+from app.util.fields import EmailField
 
 
 class Login(FlaskForm):
@@ -15,7 +16,7 @@ class Login(FlaskForm):
 
     """
 
-    email = StringField('Email', validators=[Email()])
+    email = EmailField('Email', validators=[Email()])
     password = PasswordField('Password', validators=[DataRequired()])
     submit = SubmitField('Login')
 

--- a/app/forms/quick_registration.py
+++ b/app/forms/quick_registration.py
@@ -4,7 +4,7 @@ from wtforms import (StringField, SubmitField,
 from wtforms.validators import DataRequired, Length, Email, Optional
 
 from app.models import Team
-from app.util.fields import EmailField
+from app.util.fields import EmailField, FSUIDField
 from app.util.validators import UnusedEmail
 
 
@@ -36,9 +36,9 @@ class QuickRegister(FlaskForm):
     last_name2 = StringField('Last Name', validators=[])
     last_name3 = StringField('Last Name', validators=[])
 
-    fsuid1 = StringField('FSUID', validators=[Optional(strip_whitespace=True)])
-    fsuid2 = StringField('FSUID', validators=[Optional(strip_whitespace=True)])
-    fsuid3 = StringField('FSUID', validators=[Optional(strip_whitespace=True)])
+    fsuid1 = FSUIDField('FSUID', validators=[Optional(strip_whitespace=True)])
+    fsuid2 = FSUIDField('FSUID', validators=[Optional(strip_whitespace=True)])
+    fsuid3 = FSUIDField('FSUID', validators=[Optional(strip_whitespace=True)])
 
     submit = SubmitField('Register')
 

--- a/app/forms/quick_registration.py
+++ b/app/forms/quick_registration.py
@@ -4,6 +4,7 @@ from wtforms import (StringField, SubmitField,
 from wtforms.validators import DataRequired, Length, Email, Optional
 
 from app.models import Team
+from app.util.fields import EmailField
 from app.util.validators import UnusedEmail
 
 
@@ -18,12 +19,12 @@ class QuickRegister(FlaskForm):
 
 
 
-    email1 = StringField('Email',
+    email1 = EmailField('Email',
                          validators=[Email(), UnusedEmail()])
-    email2 = StringField('Email',
+    email2 = EmailField('Email',
                          validators=[],
                          filters=[lambda x: x or None])
-    email3 = StringField('Email',
+    email3 = EmailField('Email',
                          validators=[],
                          filters=[lambda x: x or None])
 

--- a/app/forms/reset_password.py
+++ b/app/forms/reset_password.py
@@ -1,8 +1,9 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, SubmitField
+from wtforms import SubmitField
 from wtforms.validators import Email
 
 from app.util.auth2 import get_account
+from app.util.fields import EmailField
 
 
 class ResetPassword(FlaskForm):
@@ -16,7 +17,7 @@ class ResetPassword(FlaskForm):
 
     """
 
-    email = StringField('Email', validators=[
+    email = EmailField('Email', validators=[
         Email(),
     ])
 

--- a/app/forms/sign_in.py
+++ b/app/forms/sign_in.py
@@ -1,8 +1,9 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, SubmitField
+from wtforms import SubmitField
 from wtforms.validators import Email
 
 from app.util.auth2 import get_account
+from app.util.fields import EmailField
 
 
 class SignIn(FlaskForm):
@@ -12,7 +13,7 @@ class SignIn(FlaskForm):
 
     """
 
-    email = StringField('Email', validators=[Email()])
+    email = EmailField('Email', validators=[Email()])
     submit = SubmitField('Sign In')
 
     def validate(self):

--- a/app/forms/solo_register.py
+++ b/app/forms/solo_register.py
@@ -2,6 +2,7 @@ from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, SubmitField
 from wtforms.validators import DataRequired, Email, Optional
 
+from app.util.fields import EmailField
 from app.util.validators import UnusedEmail
 
 
@@ -14,7 +15,7 @@ class SoloRegister(FlaskForm):
 
     """
 
-    email = StringField('Email', validators=[
+    email = EmailField('Email', validators=[
         Email(),
         UnusedEmail()
     ])

--- a/app/forms/solo_register.py
+++ b/app/forms/solo_register.py
@@ -2,7 +2,7 @@ from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, SubmitField
 from wtforms.validators import DataRequired, Email, Optional
 
-from app.util.fields import EmailField
+from app.util.fields import EmailField, FSUIDField
 from app.util.validators import UnusedEmail
 
 
@@ -32,7 +32,7 @@ class SoloRegister(FlaskForm):
         DataRequired()
     ])
 
-    fsuid = StringField('FSUID', validators=[
+    fsuid = FSUIDField('FSUID', validators=[
         Optional(strip_whitespace=True)
     ])
 

--- a/app/models/Account.py
+++ b/app/models/Account.py
@@ -29,3 +29,10 @@ class Account(db.Document):
 
     def __repr__(self):
         return '<Account %r>' % self.email
+
+    def clean(self):
+        """
+        Make sure self.email is always lowercase. This function is
+        automatically called on self.save()
+        """
+        self.email = self.email.lower()

--- a/app/util/__init__.py
+++ b/app/util/__init__.py
@@ -1,5 +1,6 @@
 from . import auth
 from . import email
+from . import fields
 from . import filters
 from . import password
 from . import request

--- a/app/util/fields.py
+++ b/app/util/fields.py
@@ -1,0 +1,19 @@
+from wtforms.fields.html5 import EmailField as wtf_EmailField
+
+class EmailField(wtf_EmailField):
+    """Email field for WTForms
+
+    This field inherits <input type="email"> from the
+    wtforms.EmailField, but also will automatically convert
+    all data to lowercase.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        wtf_EmailField.__init__(self, *args, **kwargs)
+
+    def process_formdata(self, valuelist):
+        super(wtf_EmailField, self).process_formdata(valuelist)
+
+        if valuelist and len(valuelist) >= 1:
+            self.data = valuelist[0].lower()

--- a/app/util/fields.py
+++ b/app/util/fields.py
@@ -28,7 +28,7 @@ class FSUIDField(wtf_StringField):
     """
 
     def __init__(self, *args, **kwargs):
-        wtf_StringField.__init(self, *args, **kwargs)
+        wtf_StringField.__init__(self, *args, **kwargs)
 
     def process_formdata(self, valuelist):
         super(wtf_StringField, self).process_formdata(valuelist)

--- a/app/util/fields.py
+++ b/app/util/fields.py
@@ -1,4 +1,5 @@
 from wtforms.fields.html5 import EmailField as wtf_EmailField
+from wtforms import StringField as wtf_StringField
 
 class EmailField(wtf_EmailField):
     """Email field for WTForms
@@ -14,6 +15,23 @@ class EmailField(wtf_EmailField):
 
     def process_formdata(self, valuelist):
         super(wtf_EmailField, self).process_formdata(valuelist)
+
+        if valuelist and len(valuelist) >= 1:
+            self.data = valuelist[0].lower()
+
+
+class FSUIDField(wtf_StringField):
+    """FSUID field for custom WTForms.
+
+    This field will normalize FSUIDs to be all lowercase.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        wtf_StringField.__init(self, *args, **kwargs)
+
+    def process_formdata(self, valuelist):
+        super(wtf_StringField, self).process_formdata(valuelist)
 
         if valuelist and len(valuelist) >= 1:
             self.data = valuelist[0].lower()

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,5 +41,5 @@ vine==1.1.3
 visitor==0.1.3
 Werkzeug==0.11.11
 wrapt==1.10.11
-WTForms==2.1
+WTForms==2.2.1
 xkcdpass==1.9.2


### PR DESCRIPTION
Resolves #37 by implementing custom EmailField, extending the EmailField provided by wtforms. The wtforms Emailfield was not available on v2.1, so we upgraded to v2.2.1. 

Worth noting, this capitalization fix only applies to data entry from forms. If emails somehow otherwise enter the system, it may cause a problem. I'll look into subsequent changes to see if I can enforce lowercase-ness at the ODM level. 