### PR TITLE
Add env var to configure docs base url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js: '8'
 script: yarn docs:build
+env:
+  - URLBASE="/Contest-Server/"
 deploy:
   provider: pages
   skip-cleanup: true

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,7 +1,11 @@
+// URLBASE needs to be set for the push to Github Pages, but otherwise
+// it can be empty for local, now.sh, or netlify.
+const urlBase = process.env.URLBASE || "/";
+
 module.exports = {
     title: 'Contest Server Suite',
     description: "For running Fall & Spring Programming Contests",
-    base: "/Contest-Server/",
+    base: urlBase,
     themeConfig: {
         repo: 'fsu-acm/contest-server',
         docsDir: 'docs',


### PR DESCRIPTION
Previously you had to manually change this back and forth depending on 
whether you're using Github Pages or not, but now it's an env var so 
the travis config file will apply the right base for GH pages, otherwise
it will default to a regular base.