### PR TITLE
Fixes #56: Specify mongo image to version 3.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
 
   # Registration system database
   db:
-    image: mongo
+    image: mongo:3.6
     ports:
       - "127.0.0.1:27017:27017"
     volumes:


### PR DESCRIPTION
I chose 3.6 because that's what was used in the last contest. Latest is 4.0, but I don't want to get surprised by a breaking change.