### PR TITLE
Fix #32: validate team division after Profile creation/update

### DIFF
--- a/app/models/Profile.py
+++ b/app/models/Profile.py
@@ -62,7 +62,4 @@ class Profile(db.Document):
     # courses = db.ListField(db.ReferenceField('Course'), null=True)
 
     def __repr__(self):
-        if self.fsuid is not None:
-            return '<Profile %r>' % (self.firstname + ' ' + self.lastname)
-        else:
-            return super(Profile, self).__repr__()
+        return super(Profile, self).__repr__()

--- a/app/util/team.py
+++ b/app/util/team.py
@@ -126,12 +126,10 @@ def validate_division(team):
     """
 
     division = int(team.division)
-
     if division is 2:
-        app.logger.debug("????")
         for member in team.members:
             if member.profile:
-                if member.profile.adv_course is 'COP4530' or member.profile.adv_course is 'COP4531':
+                if member.profile.adv_course == 'COP4530' or member.profile.adv_course == 'COP4531':
                     team.division = 1
                     flash("Based a team member's furthest course, we've automatically promoted your team to Upper Division", 'info')
                     return

--- a/app/views/account/profile.py
+++ b/app/views/account/profile.py
@@ -34,20 +34,18 @@ class ProfileView(AccountFormView):
             del data['csrf_token']
             del data['submit']
 
-
             if not account.profile:
                 account.profile = Profile(**data)
             else:
                 account.profile.update(**data)
 
-            account.profile.save()
-            account.save()
-
             if account.team:
                 team_util.validate_division(account.team)
+
+            account.profile.save()
+            account.team.save()
+            account.save()
 
             flash('Profile updated')
 
         return self.render_template(form=form)
-
-


### PR DESCRIPTION
Issues involved:
 - `__repr__` of Profile model used non-existent variables (`self.fsuid`)
 - `team_util.validate_division` used `is` instead of `==` when comparing strings (comparing object IDs instead of value)
 - `account.team` object wasn't being saved after validating (division changes not saved)