### PR TITLE
Attendee check-in exceptions (Fixes #81)

### DIFF
--- a/app/templates/base2.html
+++ b/app/templates/base2.html
@@ -30,8 +30,11 @@
 
     {% block navbar %}
       {% include "common/navbar.html" %}
-      {% include "common/flash.html" %}
     {% endblock navbar %}
+
+    {% block flash %}
+      {% include "common/flash.html" %}
+    {% endblock flash %}
 
     {% block content %}
     {% endblock content %}

--- a/config/development.py
+++ b/config/development.py
@@ -5,7 +5,7 @@ TEAM_COUNT = 20
 
 # MongoDB
 MONGODB_SETTINGS = {
-	'db': "fpc2017",	# "project"
+	'db': "contest-server",	# "project"
 	'host': "localhost", 		# "127.0.0.1"
 	'port': 27017, 		# 27017
 	# 'username': "None", # 'username'
@@ -24,7 +24,7 @@ MAIL_USE_TLS = True
 MAIL_USE_SSL = False
 MAIL_DEFAULT_SENDER = 'acm@cs.fsu.edu'
 MAIL_USERNAME = 'acm'
-MAIL_PASSWORD = '1017Academic!Way'
+MAIL_PASSWORD = ''
 
 # Basic Auth Creds
 BASIC_AUTH_USERNAME = 'acm'


### PR DESCRIPTION
Re-add flask-flash widget to signin page

The flask-flash widget was originally part of the `navbar` block,
which meant that back in e2caa31 as part of #39, hiding the navbar
block on the signin page disabled the flash widget. This led to a
garbage collection error (probably due to poor programming in the
flask-flash package).

This has been corrected by giving flask-flash it's own block
outside of the navbar block.